### PR TITLE
Bug fix for !!/afk bug

### DIFF
--- a/source/plugins/afk.js
+++ b/source/plugins/afk.js
@@ -1,4 +1,4 @@
-//solves #86, written by @Shmiddty: https://gist.github.com/Shmiddty/6829439
+//solves #86, mostly written by @Shmiddty
 (function () {
 "use strict";
 
@@ -8,60 +8,111 @@ var demAFKs = bot.memory.get( 'afk' );
 var rateLimit = 5 * 60 * 1000;
 
 var responses = [
-    { 
-        outgoing: "Why are you leaving me?!", 
-        incoming: ["Welcome back!", "Where were you?!", "You saw that whore again, didn't you?!"]
-    },{ 
-        outgoing: "Just go already!", 
-        incoming: ["Oh, it's you again...", "Look at what the cat dragged in...", "You've got some balls, coming back here after what you did."]
-    },{ 
-        outgoing: "Nobody cares.", 
-        incoming: ["I already told you, nobody cares.", "There goes the neighbourhood."]
-    },{ 
-        outgoing: "Hurry back, ok?", 
-        incoming: ["I thought you'd never come back!", "It's been 20 years. You can't just waltz back into my life like this."] 
-    },{ 
-        outgoing: "Stay safe.", 
-        incoming: ["Were you bitten?! Strip! Prove you weren't bitten."] 
-    },{ 
-        outgoing: "Can you pick up some milk on your way back?", 
-        incoming: ["Where's the milk?", "Turns out I already have milk. Oops."] 
-    },{
-        outgoing: "Apricots are people too!",
-        incoming: ["You taste just like raisin.", "I am a banana!", "My spoon is too big!", "BROOOOOOOOOOOO."]
+    {
+        outgoing : 'Why are you leaving me!?',
+        incoming : [
+            'Welcome back!', 'Where were you!?',
+            'You saw that whore again, didn\'t you!?'
+        ]
+    },
+    {
+        outgoing : 'Just go already!',
+        incoming : [
+            'Oh, it\'s you again...', 'Look at what the cat dragged in...',
+            'You\'ve got some balls, coming back here after what you did.'
+        ]
+    },
+    {
+        outgoing : 'Nobody cares.',
+        incoming : [
+            'I already told you, nobody cares.',
+            'There goes the neighbourhood.'
+        ]
+    },
+    {
+        outgoing : 'Hurry back, ok?',
+        incoming : [
+            'I thought you\'d never come back!',
+            'It\'s been 20 years. You can\'t just waltz back into my life ' +
+                'like this.'
+        ]
+    },
+    {
+        outgoing : 'Stay safe.',
+        incoming : [ 'Were you bitten!? Strip! Prove you weren\'t bitten.' ]
+    },
+    {
+        outgoing : 'Can you pick up some milk on your way back?',
+        incoming : [
+            'Where\'s the milk?',
+            'Turns out I already have milk. Oops.'
+        ]
+    },
+    {
+        outgoing : 'Apricots are people too!',
+        incoming : [
+            'You taste just like raisin.', 'I am a banana!',
+            'My spoon is too big!', 'BROOOOOOOOOOOO.'
+        ]
     }
 ];
 
-var respond = function ( user, msg ) {
+var respondFor = function ( user, msg ) {
     var afkObj = demAFKs[ user ],
-        room_id = msg.get("room_id"),
-        now = Date.now(),
-        lstPing = afkObj.lastPing[room_id],
-        shouldReply = lstPing === undefined || now - lstPing >= rateLimit;
+        room_id = msg.get( 'room_id' ),
+        now = Date.now();
 
-    if ( shouldReply ){
+    if ( shouldReply() ) {
         //Send a response and such
-        msg.directreply( [user, 'is afk'+(afkObj.msg?':':'.'), afkObj.msg].join(' ') );
-        afkObj.lastPing[room_id] = now;
+        msg.directreply( formulateReponse() );
+        afkObj.lastPing[ room_id ] = now;
         bot.memory.save( 'afk' );
+    }
+
+    function formulateReponse () {
+        var format = '{user} is afk{sep}{rest}';
+        var data = {
+            user : user,
+            sep : '.',
+            rest : ''
+        };
+
+        if ( afkObj.msg ) {
+            data.sep = ': ';
+            data.rest = afkObj.msg;
+        }
+
+        return format.supplant( data );
+    }
+
+    function shouldReply () {
+        var lastPing = afkObj.lastPing[ room_id ];
+
+        if ( !lastPing ) {
+            return true;
+        }
+        return ( now - lastPing >= rateLimit );
     }
 };
 
-var goAFK = function ( user, msg, returnMsg ) {
-    demAFKs[ user ] = {
+var goAFK = function ( name, msg, returnMsg ) {
+    bot.log( '/afk goAFK ', name );
+
+    demAFKs[ name ] = {
         lastPing : {},
+        msg : msg.trim(),
         returnMsg : returnMsg,
-        msg : msg.trim()
     };
 };
 
-var clearAFK = function ( user ) {
-    delete demAFKs[ user ];
+var clearAFK = function ( name ) {
+    bot.log( '/afk clearAFK', name );
+    delete demAFKs[ name ];
 };
 
 var commandHandler = function ( msg ) {
     //parse the message and stuff.
-    var user = msg.get( 'user_name' ).replace(/ /g,''),
+    var user = msg.get( 'user_name' ).replace( /\s/g, '' ),
         afkMsg = msg.content,
         reply, botReply;
 
@@ -74,7 +125,7 @@ var commandHandler = function ( msg ) {
     else {
         botReply = responses.random();
         reply = botReply.outgoing;
-        
+
         goAFK( user, afkMsg, botReply.incoming.random() );
     }
 
@@ -88,36 +139,44 @@ bot.addCommand({
     permissions : {
         del: 'NONE'
     },
-    description : 'Set an AFK message: `!!afk <message>`. Invoke `!!afk` again' +
-        ' to return.'
+    description : 'Set an afk message: `/afk <message>`. Invoke `/afk` ' +
+        'again to return.'
 });
 
-IO.register( 'input', function ( msgObj ) {
+IO.register( 'input', function afkInputListener ( msgObj ) {
     var body = msgObj.content.toUpperCase(),
         msg = bot.prepareMessage( msgObj ),
-        rgx = new RegExp( '^' + bot.invocationPattern + ' ?/? ?afk', 'i' );
-    
-    if ( demAFKs.hasOwnProperty(msgObj.user_name.replace(/ /g,'')) 
-         && rgx.test(body) === false ) {
-        // the user posted, and did not invoke the afk command
-        // TODO: It might be a good idea to extract this into something like
-        // bot.getCommandNameFromMessage(msgObj) 
-        // which would return the string name for a valid command message,
-        // or undefined for an message that contains an invalid command or no command.
-        commandHandler(msg);
-        
-        // We don't want to return here, as the returning user could be pinging someone. 
-    }
-    
-    //we only care about messages not made by the bot, and containing pings
-    if ( msgObj.user_id === bot.adapter.user_id || body.indexOf('@') < 0 ) {
+        userName = msgObj.user_name.replace( /\s/g, '' ),
+        id = msgObj.user_id;
+
+    //we don't care about bos messages
+    if ( id === bot.adapter.user_id ) {
         return;
     }
 
-    Object.keys( demAFKs ).forEach(function ( name ) {
+    //if the user posts, we want to release them from afk's iron grip. however
+    // to prevent activating it twice, we need to check whether they're calling
+    // the bot's afk command already.
+    var invokeRe = new RegExp(
+        '^' + RegExp.escape( bot.invocationPattern ) + ' ?/? ?AFK' );
+
+    console.log( userName, invokeRe.test(body) );
+    if ( demAFKs.hasOwnProperty(userName) && !invokeRe.test(body) ) {
+        bot.log( '/afk he returned!', msgObj );
+        commandHandler( msg );
+        //We don't want to return here, as the returning user could be pinging
+        // someone.
+    }
+
+    //and we don't care if the message doesn't have any pings
+    if ( body.indexOf('@') < 0 ) {
+        return;
+    }
+
+    Object.keys( demAFKs ).forEach(function afkCheckAndRespond ( name ) {
         if ( body.indexOf('@'+name.toUpperCase()) > -1 ) {
             bot.log( '/afk responding for ' + name );
-            respond( name, msg );
+            respondFor( name, msg );
         }
     });
 });


### PR DESCRIPTION
When invoking the command with the option slash `!!/afk`, It would ping the user twice immediately (going and returning from afk) because the input event didn't properly handle the optional slash. 

At some point we may want to extract this code into a helper method on the `bot` object.

Something like `bot.getCommandNameFromMessage` which would return a string for a valid command, or undefined for a message with an invalid command or no command. 
