### PR TITLE
Command filtering didn't account for slash

### DIFF
--- a/source/plugins/afk.js
+++ b/source/plugins/afk.js
@@ -158,7 +158,7 @@ IO.register( 'input', function afkInputListener ( msgObj ) {
     // to prevent activating it twice, we need to check whether they're calling
     // the bot's afk command already.
     var invokeRe = new RegExp(
-        '^' + RegExp.escape( bot.invocationPattern ) + '\\s*AFK' );
+        '^' + RegExp.escape( bot.invocationPattern ) + '\\s*\/?\\s*AFK' );
 
     console.log( userName, invokeRe.test(body) );
     if ( demAFKs.hasOwnProperty(userName) && !invokeRe.test(body) ) {


### PR DESCRIPTION
When we were filtering for `!!afk` messages, we didn't account for the now-optional slash `!!/afk`
