### PR TITLE
Modify output for 'help' command

### DIFF
--- a/source/commands.js
+++ b/source/commands.js
@@ -17,7 +17,7 @@ var commands = {
 
 		return 'Information on interacting with me can be found at ' + 
 			'[this page](https://github.com/Zirak/SO-ChatBot/' +
-			'wiki/Interacting-with-the-bot';
+			'wiki/Interacting-with-the-bot)';
 	},
 
 	listen : function ( msg ) {


### PR DESCRIPTION
Modify output for 'help' command to make it an actual sentence, and to use link formatting for StackExchange Chat so that it displays "here" as a clickable link to the "Interacting with the Bot" document for the bot here on Github.
