### PR TITLE
Address a specific bot

### DIFF
--- a/source/plugins/address.js
+++ b/source/plugins/address.js
@@ -5,8 +5,13 @@ var botName = bot.users[ bot.adapter.user_id ].name,
 IO.register( 'input', function ( msgObj ) {
 	var message = msgObj.content;
 
-	if ( message.indexOf(addresser + bot.invocationPattern) === 0 ) {
-		msgObj.content = message.substring( addresser.length );
+	if ( message.indexOf(addresser) === 0 ) {
+		message = msgObj.content = message.substring( addresser.length );
+
+		if ( message.indexOf(bot.invocationPattern) !== 0 ) {
+			msgObj.content = bot.invocationPattern + message;
+		}
+
 		bot.parseMessage( msgObj );
 	}
 });


### PR DESCRIPTION
Allows you to invoke commands using `@BotName234234234 !!command`, and have any bot with the same invocation pattern ignore that.

solves #124 and point 1 by Zirak in #65
