### PR TITLE
Fixes listcommands; status 500 error

### DIFF
--- a/source/commands.js
+++ b/source/commands.js
@@ -15,8 +15,9 @@ var commands = {
 			return args + ': ' + desc;
 		}
 
-		return 'https://github.com/Zirak/SO-ChatBot/wiki/' +
-			'Interacting-with-the-bot';
+		return 'Information on interacting with me can be found at ' +
+			'[this page](https://github.com/Zirak/SO-ChatBot/' +
+			'wiki/Interacting-with-the-bot)';
 	},
 
 	listen : function ( msg ) {
@@ -342,8 +343,12 @@ var partition = function ( list, maxSize ) {
 
 return function ( args ) {
 	var commands = Object.keys( bot.commands ),
+		pages = ' (page {0}/{1})',
+		sweetData = args.get(),
+		// 500 minus 2 for @ and space, minus pagination length, minus the user's name length
+		maxSize = 498 - pages.length - sweetData.user_name.length,
 		//TODO: only call this when commands were learned/forgotten since last
-		partitioned = partition( commands ),
+		partitioned = partition( commands, maxSize ),
 
 		valid = /^(\d+|$)/.test( args.content ),
 		page = Number( args.content ) || 0;
@@ -359,7 +364,7 @@ return function ( args ) {
 
 	var ret = partitioned[ page ].join( ', ' );
 
-	return ret + ' (page {0}/{1})'.supplant( page, partitioned.length-1 );
+	return ret + pages.supplant( page, partitioned.length-1 );
 };
 })();
 


### PR DESCRIPTION
Some people <a href="http://chat.stackoverflow.com/transcript/message/13154994#13154994">with really long names</a> are getting a status 500 error on listcommands, because a 20 char buffer zone is not enough. This <a href="http://chat.stackoverflow.com/transcript/message/13155861#13155861">patch fixes that</a>, by taking username lengths into account. `pages.length` adds an extra 4 char buffer zone (counting the brackets), so we should be good, up to 1,000 commands.

Idk what L18-L20 comparison is all about, that should be old news already.
