### PR TITLE
Fixes listcommands; status 500 error

### DIFF
--- a/source/commands.js
+++ b/source/commands.js
@@ -343,8 +343,12 @@ var partition = function ( list, maxSize ) {
 
 return function ( args ) {
 	var commands = Object.keys( bot.commands ),
+		pagination = ' (page {0}/{1})',
+		user_name = args.get( 'user_name' ),
+		// 500 minus 2 for @ and space, minus pagination length, minus the user's name length
+		maxSize = 498 - pagination.length - user_name.length,
 		//TODO: only call this when commands were learned/forgotten since last
-		partitioned = partition( commands ),
+		partitioned = partition( commands, maxSize ),
 
 		valid = /^(\d+|$)/.test( args.content ),
 		page = Number( args.content ) || 0;
@@ -360,7 +364,7 @@ return function ( args ) {
 
 	var ret = partitioned[ page ].join( ', ' );
 
-	return ret + ' (page {0}/{1})'.supplant( page, partitioned.length-1 );
+	return ret + pagination.supplant( page, partitioned.length-1 );
 };
 })();
 


### PR DESCRIPTION
Some people with really long names are getting a status 500 error on listcommands (http://chat.stackoverflow.com/transcript/message/13154994#13154994), because a 20 char buffer zone is not enough. This patch fixes that (http://chat.stackoverflow.com/transcript/message/13155861#13155861), by taking username lengths into account. `pagination.length` adds an extra 4 char buffer zone (counting the brackets), so we should be good for up to 1,000 commands.
