### PR TITLE
Remove commands from the suggestion dictionary on forget

### DIFF
--- a/source/bot.js
+++ b/source/bot.js
@@ -357,6 +357,7 @@ bot.Command = function ( cmd ) {
 	cmd.del = function () {
 		bot.info.forgotten += 1;
 		delete bot.commands[ cmd.name ];
+		bot.commandDictionary.trie.del(cmd.name);
 	};
 
 	return cmd;

--- a/source/suggestionDict.js
+++ b/source/suggestionDict.js
@@ -22,6 +22,24 @@ TrieNode.prototype.add = function( word ) {
 	node.word = word;
 };
 
+TrieNode.prototype.del = function(word, i) {
+	i = i || 0;
+	var node = this;
+	var char = word[i++];
+
+	// recursively delete all trie nodes that are left empty after removing the command from the leaf
+	if (node.children[char]) {
+		node.children[char].del(word, i);
+		if (Object.keys(node.children[char].children).length === 0 && node.children[char].word === null) {
+			delete node.children[char];
+		}
+	}
+	
+	if (node.word === word) {
+		node.word = null;
+	}
+}
+
 //Having a small maxCost will increase performance greatly, experiment with
 //values of 1-3
 function SuggestionDictionary ( maxCost ) {


### PR DESCRIPTION
Currently, commands are never removed from the suggestion dictionary. Even after using the `forget` command, the forgotten commands are still suggested when you attempt to use them.

This fixes that. Probably not very clean, but it works.
