### PR TITLE
Making unbans actually save

### DIFF
--- a/source/bot.js
+++ b/source/bot.js
@@ -328,6 +328,7 @@ bot.banlist.add = function ( id ) {
 bot.banlist.remove = function ( id ) {
 	if ( this.contains(id) ) {
 		delete this[ id ];
+		bot.memory.save( 'ban' );
 	}
 };
 


### PR DESCRIPTION
Restarting the bot lost all unbans so the banlist only ever grew. Just missing a bot.memory.save after deleting the ban entry even though it saved when it was added.
