### PR TITLE
Github is not a cdn, rawgithub is.

### DIFF
--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -1,1 +1,1 @@
-(function(){var a=document.createElement("script");a.src="https://raw.github.com/Zirak/SO-ChatBot/master/master.js",document.head.appendChild(a)})()
+(function(){var a=document.createElement("script");a.src="https://rawgithub.com/Zirak/SO-ChatBot/master/master.js",document.head.appendChild(a)})()


### PR DESCRIPTION
This fixes the bookmarklet in chrome.