### PR TITLE
Have a separate config file for headless mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 node_modules/
 data/
 *.jar
+
+// ignore local config files; only commit ones with .SAMPLE
+*.config.json

--- a/run-headless.config.json.SAMPLE
+++ b/run-headless.config.json.SAMPLE
@@ -1,0 +1,7 @@
+{
+	"email": "you can guess",
+	"password": "what these are",
+
+	"siteUrl": "https://stackoverflow.com",
+	"roomUrl": "https://chat.stackoverflow.com/rooms/1"
+}

--- a/run-headless.js
+++ b/run-headless.js
@@ -1,18 +1,12 @@
 var Nightmare = require('nightmare'),
-	readline = require('readline');
+	readline = require('readline'),
+	fs = require('fs');
 
 var hound = new Nightmare({
 	cookiesFile: 'cookies.jar'
 });
 
-/***********	Change me!	  ***********/
-var config = {
-	email:	  'you can guess',
-	password: 'what these are',
-
-	siteUrl: 'https://stackoverflow.com',
-	roomUrl: 'https://chat.stackoverflow.com/rooms/1'
-};
+var config = JSON.parse(fs.readFileSync('run-headless.config.json', 'utf8'));
 
 function once (fn) {
 	var called = false, res;


### PR DESCRIPTION
Having had a few... accidents... recently, I thought this might be useful.

Just separating the config for headless mode and adding that config to `.gitignore` to reduce the risk of accidentally committing/pushing account details.