### PR TITLE
Change CDN to rawgit.com

### DIFF
--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -1,1 +1,1 @@
-(function(){var a=document.createElement("script");a.src="https://rawgithub.com/Zirak/SO-ChatBot/master/master.js",document.head.appendChild(a)})()
+(function(){var a=document.createElement("script");a.src="https://rawgit.com/Zirak/SO-ChatBot/master/master.js",document.head.appendChild(a)})()


### PR DESCRIPTION
Actually, rawgithub.com is only a redirect to rawgit.com, which is the real CDN.