### PR TITLE
Fixed a sorting issue

### DIFF
--- a/master.js
+++ b/master.js
@@ -1903,7 +1903,7 @@ function getSortedCommands() {
     });
 
     var sortedCommands = commandGroups.builtin.sort().concat(
-        commandGroups.learned.sort()
+        commandGroups.learned ? commandGroups.learned.sort() : []
     );
 
     var helpIndex = sortedCommands.indexOf('help');


### PR DESCRIPTION
Previously, it would throw an error if there's only builtins and no learned commands, as you can't concat null.